### PR TITLE
hcloud: Add cx22-cx52 machine types

### DIFF
--- a/charts/cloudprofiles/charts/hcloud/values.yaml
+++ b/charts/cloudprofiles/charts/hcloud/values.yaml
@@ -20,12 +20,20 @@ machineTypes:
     cpu: "2"
     memory: 4Gi
     gpu: "0"
+  - name: cx22
+    cpu: "2"
+    memory: 4Gi
+    gpu: "0"
   - name: cpx21
     cpu: "3"
     memory: 4Gi
     gpu: "0"
   - name: cx31
     cpu: "2"
+    memory: 8Gi
+    gpu: "0"
+  - name: cx32
+    cpu: "4"
     memory: 8Gi
     gpu: "0"
   - name: cpx31
@@ -36,12 +44,20 @@ machineTypes:
     cpu: "4"
     memory: 16Gi
     gpu: "0"
+  - name: cx42
+    cpu: "8"
+    memory: 16Gi
+    gpu: "0"
   - name: cpx41
     cpu: "8"
     memory: 16Gi
     gpu: "0"
   - name: cx51
     cpu: "8"
+    memory: 32Gi
+    gpu: "0"
+  - name: cx52
+    cpu: "16"
     memory: 32Gi
     gpu: "0"
   - name: cpx51


### PR DESCRIPTION
hcloud have added [new machine types cx22-cx52](https://docs.hetzner.cloud/whats-new#2024-06-06-new-shared-vcpu-servers-with-intel-processors), to replace cx11-cx51. This adds cx22-cx52 as a first step, so that people are able to migrate away from cx21-cx51. We'll remove those at a later time. cx21-cx51 will be available until 2024-09-06