### PR TITLE
Update hcloud machine types

### DIFF
--- a/charts/cloudprofiles/charts/hcloud/values.yaml
+++ b/charts/cloudprofiles/charts/hcloud/values.yaml
@@ -16,10 +16,6 @@ machineImages:
       cri:
       - name: containerd
 machineTypes:
-  - name: cx21
-    cpu: "2"
-    memory: 4Gi
-    gpu: "0"
   - name: cx22
     cpu: "2"
     memory: 4Gi
@@ -27,10 +23,6 @@ machineTypes:
   - name: cpx21
     cpu: "3"
     memory: 4Gi
-    gpu: "0"
-  - name: cx31
-    cpu: "2"
-    memory: 8Gi
     gpu: "0"
   - name: cx32
     cpu: "4"
@@ -40,10 +32,6 @@ machineTypes:
     cpu: "4"
     memory: 8Gi
     gpu: "0"
-  - name: cx41
-    cpu: "4"
-    memory: 16Gi
-    gpu: "0"
   - name: cx42
     cpu: "8"
     memory: 16Gi
@@ -51,10 +39,6 @@ machineTypes:
   - name: cpx41
     cpu: "8"
     memory: 16Gi
-    gpu: "0"
-  - name: cx51
-    cpu: "8"
-    memory: 32Gi
     gpu: "0"
   - name: cx52
     cpu: "16"
@@ -122,10 +106,10 @@ regions:
     zones:
       - name: ash-dc1
         unavailableMachineTypes:
-        - cx21
-        - cx31
-        - cx41
-        - cx51
+        - cx22
+        - cx32
+        - cx42
+        - cx52
         - ccx11
         - ccx21
         - ccx31

--- a/charts/cloudprofiles/charts/hcloud/values.yaml
+++ b/charts/cloudprofiles/charts/hcloud/values.yaml
@@ -92,6 +92,26 @@ machineTypes:
     cpu: "48"
     memory: 192Gi
     gpu: "0"
+  - name: cax11
+    cpu: "2"
+    memory: 4Gi
+    gpu: "0"
+    architecture: arm64
+  - name: cax21
+    cpu: "4"
+    memory: 8Gi
+    gpu: "0"
+    architecture: arm64
+  - name: cax31
+    cpu: "8"
+    memory: 16Gi
+    gpu: "0"
+    architecture: arm64
+  - name: cax41
+    cpu: "16"
+    memory: 32Gi
+    gpu: "0"
+    architecture: arm64
 regions:
   - name: hel1
     zones:
@@ -115,6 +135,10 @@ regions:
         - ccx31
         - ccx41
         - ccx51
+        - cax11
+        - cax21
+        - cax31
+        - cax41
 providerConfig:
   apiVersion: hcloud.provider.extensions.gardener.cloud/v1alpha1
   kind: CloudProfileConfig


### PR DESCRIPTION
Add cax21-51 machine types (ARM64)
Remove obsolete cx21-51 (replaced by cx22-52)